### PR TITLE
Triggers and Swap Setups corrections, and algorithms update

### DIFF
--- a/CPLINE/DLS/dls.html
+++ b/CPLINE/DLS/dls.html
@@ -168,14 +168,14 @@
                 <tbody>
                     <tr>
                         <td>F' U' F</td>
-                        <td>F R' F'</td>
+                        <td>F R2 F'</td>
                         <td>UFR - UFL</td>
                         <td>UBR - DBR</td>
                         <td>UBL - DFR</td>
                     </tr>
                     <tr>
                         <td>F' U F</td>
-                        <td>F R2 F'</td>
+                        <td>F R' F'</td>
                         <td>UFR - UBR</td>
                         <td>UBL - DBR</td>
                         <td>UFL - DFR</td>

--- a/CPLINE/DLS/dls.html
+++ b/CPLINE/DLS/dls.html
@@ -155,10 +155,11 @@
             <p>The first step, CP-Line, involves solving a 1x1x3 bar in DL while solving corner permutation. If the DL corners are already solved (as they are about 40% of the times for an x2 y neutral solver, and about 25% of the time for an x2 y2 neutal solver), after identifying the corner pair options that can be swapped, any one pair of corners can be set up to one of the above configurations using R, U and slice moves, and the corresponding trigger can be done to solve CP while keeping the DL corners solved. The trigger can have wide moves as and when necessary to ensure efficiency of solving the DL edge. While the knwledge of only one trigger is sufficient to solve CP (especially since the configurations are only a U move away from each other), having multiple triggers at our disposal can help affect the DL edge in various ways.</p>
             <p>While the above summarises how each of the four triggers works, an advanced solver may get some help from the following table. Most users will however not require the following on any account.</p>
 
-                        <table>
+            <table id="triggers">
                 <thead>
                     <tr>
-                        <th>Trigger</th>
+                        <th>Trigger (opt 1)</th>
+                        <th>Trigger (opt 2)</th>
                         <th>Swap Setup 1</th>
                         <th>Swap Setup 2</th>
                         <th>Swap Setup 3</th>
@@ -167,26 +168,23 @@
                 <tbody>
                     <tr>
                         <td>F' U' F</td>
+                        <td>F' R' F</td>
                         <td>UFR - UFL</td>
                         <td>UBR - DBR</td>
                         <td>UBL - DFR</td>
                     </tr>
                     <tr>
                         <td>F' U F</td>
+                        <td>F' R2 F</td>
                         <td>UFR - UBR</td>
                         <td>UBL - DBR</td>
                         <td>UFL - DFR</td>
                     </tr>
                     <tr>
                         <td>F R F'</td>
+                        <td>F' U2 F</td>
                         <td>UBR - UBL</td>
                         <td>UFR - DFR</td>
-                        <td>UFL - DBR</td>
-                    </tr>
-                    <tr>
-                        <td>F R' F'</td>
-                        <td>UFR - UBR</td>
-                        <td>UBL - DFR</td>
                         <td>UFL - DBR</td>
                     </tr>
                 </tbody>

--- a/CPLINE/DLS/dls.html
+++ b/CPLINE/DLS/dls.html
@@ -168,14 +168,14 @@
                 <tbody>
                     <tr>
                         <td>F' U' F</td>
-                        <td>F' R' F</td>
+                        <td>F R' F'</td>
                         <td>UFR - UFL</td>
                         <td>UBR - DBR</td>
                         <td>UBL - DFR</td>
                     </tr>
                     <tr>
                         <td>F' U F</td>
-                        <td>F' R2 F</td>
+                        <td>F R2 F'</td>
                         <td>UFR - UBR</td>
                         <td>UBL - DBR</td>
                         <td>UFL - DFR</td>

--- a/CPLINE/DLU/dlu.html
+++ b/CPLINE/DLU/dlu.html
@@ -123,13 +123,13 @@
             <div class="box">
                 <center><img src="c.png"></center>
                 <h3>Special Case</h3>
-                <p>It may happen that the DL corners are not correctly permuted, however the CP is solved (i.e. tracing gives the sequence 12). Thus, we do not have any corner to place in the UBR position and solve as mentioned. In this case, set up the corner that belongs in DFL an F2 away from being solved (as shown in the figure above), while preserving CP; then do <b>F U F</b> or <b>F' R' F'</b> to solve the DL corners while maintaining CP. [One can also set up an F or F' away and do <b>F U' F U' F'</b> or <b>F' R F' R F</b> respectively.]</p>
+                <p>It may happen that the DL corners are not correctly permuted, however the CP is solved (i.e. tracing gives the sequence 12). Thus, we do not have any corner to place in the UBR position and solve as mentioned. In this case, set up the corner that belongs in DFL an F2 away from being solved (as shown in the figure above), while preserving CP; then do <b>F U F</b> or <b>F' R' F'</b> to solve the DL corners while maintaining CP. [One can also set up an F or F' away and do <b>U F' U' F'</b> or <b>R' F R F</b> respectively.]</p>
             </div>
 
             <div class="box">
                 <center><img src="d.png"></center>
                 <h3>Nightmare Case</h3>
-                <p>If the DFL corner is twisted in place, then simply pick another orientation to solve since these cases are rare and inefficient. However, for an x2 y2 neutral solver, once every ~2000 solves, it may happen that all DL corner pairs are permuted correctly but twisted in place. In such a scenario, one could do normal tracing to get CP, and place a corner swap pair in UFL and DFR while preserving CP, then do one of the following depending on the direction of twist: either <b>F2 R’ F R’ F R’ F</b> or <b>F2 U F’ U F’ U F</b></p>
+                <p>If the DFL corner is twisted in place, then simply pick another orientation to solve since these cases are rare and inefficient. However, for an x2 y2 neutral solver, once every ~2000 solves, it may happen that all DL corner pairs are permuted correctly but twisted in place. In such a scenario, one could do normal tracing to get CP, and place a corner swap pair in UFL and DFR while preserving CP, then do one of the following depending on the direction of twist: <b>F' R F' R F'</b> for clockwise and <b>F U' F U' F </b> for counter-clockwise. Double sexy or antisexy can also be performed (<b>F U F' U' F U F'</b> or <b>F U' F' U F U' F'</b>)</p>
             </div>
         </div>
     </section>

--- a/CPLINE/beginners/beginners.html
+++ b/CPLINE/beginners/beginners.html
@@ -161,7 +161,7 @@
                         <th>Option 1</th>
                         <th>Option 2</th>
                         <th>Option 3</th>
-                        <th>Comments</th>
+                        <th id="comments">Comments</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/style.css
+++ b/style.css
@@ -167,11 +167,11 @@ header .dropdown:hover .primary{
   border-right:2px solid black;
 }
 
-#rest th:nth-child(5){
+#rest #comments{
   width:50%;
 }
 
-#rest tr td:nth-child(1){
+#rest tr td:nth-child(1), #rest #triggers tr td:nth-child(2){
   font-weight: bold;
   letter-spacing: 0.2em;
 }


### PR DESCRIPTION
Instead of 4 groups for Swap Setups, I found there are only 3. The fourth trigger (F R' F') solves the same group of Swap Setups as the first trigger (F' U' F). 

Changes: 
- Add two new triggers (F R2 F' & F' U2 F) so each group of Swap Setups has two options. The new table would look as follows: 

| **Trigger (opt 1)** | **Trigger (opt 2)** | Swap Setup 1 | Swap Setup 2 | Swap Setup 3 |
|:---------------:|:---------------:|:------------:|:------------:|:------------:|
|     **F' U' F**     |     **F R' F'**     |   UFR - UFL  |   UBR - DBR  |   UBL - DFR  |
|      **F' U F**     |     **F R2 F'**     |   UFR - UBR  |   UBL - DBR  |   UFL - DFR  |
|      **F R F'**     |     **F' U2 F**     |   UBR - UBL  |   UFR - DFR  |   UFL - DBR  |
- Update algorithms for:
  - Special case (DFL not solved, CP solved)
  - Nightmare case (DFL twisted, CP solved)


